### PR TITLE
Add normalization and completetion

### DIFF
--- a/code_rypl/document.py
+++ b/code_rypl/document.py
@@ -355,14 +355,9 @@ class CodeRyplDocumentWindow(QMainWindow):
             prompt=suggested_season,
             normalize=renderer_tools.normalize_season,
             suggestions=[suggested_season],
+            suggestion_inline=True,
             on_change=lambda: self.model.set_meta(category=season_input.text()),
         )
-
-        # season_input.returnPressed.connect(
-        #     lambda: season_input.setText(
-        #         suggested_season if (raw := season_input.text()).strip() == "" else raw
-        #     )
-        # )
 
         # add the widgets to the layout
         metalayout.addWidget(school_input)
@@ -379,6 +374,7 @@ class CodeRyplDocumentWindow(QMainWindow):
         on_change: Callable[[], None] | None = None,
         normalize: Callable[[str], str] | None = None,
         suggestions: Iterable[str] | None = None,
+        suggestion_inline: bool = False,
     ) -> QLineEdit:
 
         widget = QLineEdit("")
@@ -401,7 +397,11 @@ class CodeRyplDocumentWindow(QMainWindow):
             completer.setCaseSensitivity(Qt.CaseInsensitive)
 
             # make the complete show on focus
-            completer.setCompletionMode(QCompleter.PopupCompletion)
+            if suggestion_inline:
+                completer.setCompletionMode(QCompleter.InlineCompletion)
+            else:
+                completer.setCompletionMode(QCompleter.PopupCompletion)
+            # completer.setCompletionMode(QCompleter.UnfilteredPopupCompletion)
 
             # TODO: to show the completer on focus override the focusChanged method
             # on the app and pass a callback down to this

--- a/code_rypl/document.py
+++ b/code_rypl/document.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 import pathlib
+import time
 
 from typing import *
 
@@ -9,10 +10,8 @@ from .model import RplmFile, RplmList, blocking_popup
 from .table import RplmTableView
 
 # import the necessary modules
-import PySide6 as pyside
-from PySide6 import QtCore, QtGui, QtWidgets
 from PySide6.QtGui import QFontMetrics
-
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QWidget,
     QMainWindow,
@@ -22,7 +21,13 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QTabWidget,
     QMenuBar,
+    QCompleter,
+    QStyleFactory,
+    QFileDialog,
 )
+
+from .renderers import tools as renderer_tools
+
 
 if TYPE_CHECKING:
     from .app import CodeRyplApplication
@@ -110,7 +115,7 @@ class CodeRyplMenuBar(QMenuBar):
         # TODO: add an edit meu for removing blank lines, etc.
 
     def open_file(self) -> None:
-        filename, _ = QtWidgets.QFileDialog.getOpenFileName(
+        filename, _ = QFileDialog.getOpenFileName(
             self, "Open File", "", "RPLM Files (*.rplm)"
         )
 
@@ -145,28 +150,14 @@ class CodeRyplDocumentWindow(QMainWindow):
 
         self.init_layout()
 
-        model = RplmFile.untitled() if filename is None else RplmFile.open(filename)
-        self.load_file_model(model)
+        self.load_file_model(
+            RplmFile.untitled() if filename is None else RplmFile.open(filename)
+        )
 
         # file export state
         self._last_export_path = (
             pathlib.Path.home() if filename is None else pathlib.Path(filename).parent
         )
-
-    def load_file_model(self, model: RplmFile) -> None:
-
-        self.model = model
-        self.setWindowTitle(
-            f"CodeRyple - {'Untitled.rplm' if model.filename is None else model.filename}"
-        )
-
-        self.coach_table.load_rplm_list(model.coaches)
-        self.player_table.load_rplm_list(model.players)
-
-        self.school_input.setText(model.school)
-        self.sport_input.setText(model.sport)
-        self.category_input.setText(model.category)
-        self.season_input.setText(model.season)
 
     def get_focused_table(self) -> None | RplmTableView:
         if self.coach_table.hasFocus():
@@ -199,7 +190,7 @@ class CodeRyplDocumentWindow(QMainWindow):
                 suggested_filename = "SaveAs"
 
         # open the file dialog
-        filename, _ = QtWidgets.QFileDialog.getSaveFileName(
+        filename, _ = QFileDialog.getSaveFileName(
             self,
             "Save File As",
             str(self._last_export_path / f"{suggested_filename}.rplm"),
@@ -236,7 +227,7 @@ class CodeRyplDocumentWindow(QMainWindow):
             exportname = self._resolve_suggested_filename(renderer, "Untitled") + ".txt"
 
             # promot the user to select a file
-            raw_exportpath, _ = QtWidgets.QFileDialog.getSaveFileName(
+            raw_exportpath, _ = QFileDialog.getSaveFileName(
                 self,
                 caption="Export File",
                 dir=str(self._last_export_path / exportname),
@@ -317,7 +308,7 @@ class CodeRyplDocumentWindow(QMainWindow):
         tab_widget.tabBar().setDocumentMode(True)
         tab_widget.tabBar().setExpanding(True)
         # TODO: make the selected tab color a little better, but fine for now
-        tab_widget.tabBar().setStyle(QtWidgets.QStyleFactory.create("Fusion"))
+        tab_widget.tabBar().setStyle(QStyleFactory.create("Fusion"))
 
         # --- the player table ---
         self.player_table = player_table = RplmTableView()
@@ -337,39 +328,41 @@ class CodeRyplDocumentWindow(QMainWindow):
 
         # make the inputs
         # TODO: make the default values based on teh laoded file_modle
-        self.school_input = school_input = QLineEdit("")
-        school_input.setPlaceholderText("School of Name")
-        school_input.setFixedHeight(
-            int(QFontMetrics(school_input.font()).height() * 1.8)
-        )
-        school_input.textEdited.connect(
-            lambda: self.model.set_meta(school=school_input.text())
+        self.school_input = school_input = self._make_metatext_input(
+            prompt="School of Name",
+            normalize=renderer_tools.normalize_school,
+            on_change=lambda: self.model.set_meta(school=school_input.text()),
         )
 
-        self.sport_input = sport_input = QLineEdit("")
-        sport_input.setPlaceholderText("SportsBall")
-        sport_input.setFixedHeight(int(QFontMetrics(sport_input.font()).height() * 1.8))
-        sport_input.textEdited.connect(
-            lambda: self.model.set_meta(sport=sport_input.text())
+        self.sport_input = sport_input = self._make_metatext_input(
+            prompt="SportsBall",
+            suggestions=renderer_tools.sport_abrev_to_formal_name.values(),
+            normalize=renderer_tools.normalize_sports,
+            on_change=lambda: self.model.set_meta(sport=sport_input.text()),
         )
 
-        self.category_input = category_input = QLineEdit("")
-        category_input.setPlaceholderText("mens, womens, etc")
-        category_input.setFixedHeight(
-            int(QFontMetrics(category_input.font()).height() * 1.8)
-        )
-        category_input.textEdited.connect(
-            lambda: self.model.set_meta(category=category_input.text())
+        self.category_input = category_input = self._make_metatext_input(
+            prompt="Men's, Women's, etc",
+            suggestions=renderer_tools.category_formal_to_variations,
+            normalize=renderer_tools.normalize_category,
+            on_change=lambda: self.model.set_meta(category=category_input.text()),
         )
 
-        self.season_input = season_input = QLineEdit("")
-        season_input.setPlaceholderText("year")
-        season_input.setFixedHeight(
-            int(QFontMetrics(season_input.font()).height() * 1.8)
+        this_year = time.localtime().tm_year
+        suggested_season = f"{this_year:04}-{(this_year+1)%100:02}"
+
+        self.season_input = season_input = self._make_metatext_input(
+            prompt=suggested_season,
+            normalize=renderer_tools.normalize_season,
+            suggestions=[suggested_season],
+            on_change=lambda: self.model.set_meta(category=season_input.text()),
         )
-        season_input.textEdited.connect(
-            lambda: self.model.set_meta(season=season_input.text())
-        )
+
+        # season_input.returnPressed.connect(
+        #     lambda: season_input.setText(
+        #         suggested_season if (raw := season_input.text()).strip() == "" else raw
+        #     )
+        # )
 
         # add the widgets to the layout
         metalayout.addWidget(school_input)
@@ -378,3 +371,64 @@ class CodeRyplDocumentWindow(QMainWindow):
         metalayout.addWidget(season_input)
 
         return metalayout
+
+    def _make_metatext_input(
+        self,
+        *,
+        prompt: str,
+        on_change: Callable[[], None] | None = None,
+        normalize: Callable[[str], str] | None = None,
+        suggestions: Iterable[str] | None = None,
+    ) -> QLineEdit:
+
+        widget = QLineEdit("")
+        metrics = QFontMetrics(widget.font())
+        widget.setPlaceholderText(prompt)
+        widget.setFixedHeight(int(metrics.height() * 1.8))
+
+        if on_change is not None:
+            widget.textChanged.connect(on_change)
+
+        if normalize is not None:
+            widget.editingFinished.connect(
+                lambda: widget.setText(normalize(widget.text()))
+            )
+
+        if suggestions is not None:
+            # make a completer
+            completer = QCompleter(list(suggestions))
+            # set the completer to be case insensitive
+            completer.setCaseSensitivity(Qt.CaseInsensitive)
+
+            # make the complete show on focus
+            completer.setCompletionMode(QCompleter.PopupCompletion)
+
+            # TODO: to show the completer on focus override the focusChanged method
+            # on the app and pass a callback down to this
+            # (or something like enviroment variable)
+
+            # fuzzy matching
+            completer.setFilterMode(Qt.MatchContains)
+            # set the completer
+            widget.setCompleter(completer)
+
+        return widget
+
+    def load_file_model(self, model: RplmFile) -> None:
+
+        self.model = model
+        self.setWindowTitle(
+            f"CodeRyple - {'Untitled.rplm' if model.filename is None else model.filename}"
+        )
+
+        self.coach_table.load_rplm_list(model.coaches)
+        self.player_table.load_rplm_list(model.players)
+
+        if len(model.school):
+            self.school_input.setText(model.school)
+        if len(model.sport):
+            self.sport_input.setText(model.sport)
+        if len(model.category):
+            self.category_input.setText(model.category)
+        if len(model.season):
+            self.season_input.setText(model.season)

--- a/code_rypl/model.py
+++ b/code_rypl/model.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import sys
+import time
 from typing import *
 from typing import TextIO, BinaryIO
 
@@ -155,6 +155,14 @@ class RplmFile:
 
     metadata_spec: ClassVar[set[str]] = {"school", "sport", "category", "season"}
 
+    filename: None | str
+    school: str
+    sport: str
+    category: str
+    season: str
+    players: RplmList[Player]
+    coaches: RplmList[Coach]
+
     def __init__(
         self,
         *,
@@ -165,7 +173,7 @@ class RplmFile:
         season: str = "",
         players: Iterable[Player] | None = None,
         coaches: Iterable[Coach] | None = None,
-        set_selected_cell: Callable[[QModelIndex], None] = None,
+        set_selected_cell: Callable[[QModelIndex], None] | None = None,
     ) -> None:
         super().__init__()
 
@@ -307,14 +315,18 @@ class RplmFile:
 
     def export_into(self, file: TextIO, *, renderer: RplmFileRenderer) -> None:
 
+        remove_colons: Callable[[dict[str, str]], dict[str, str]] = lambda dct: {
+            k: v.lstrip(":") for k, v in dct.items()
+        }
+
         file.writelines(
-            renderer.render_player(**player.as_fields()) + "\n"
+            renderer.render_player(**remove_colons(player.as_fields())) + "\n"
             for player in self.players
             if not player.isempty()
         )
 
         file.writelines(
-            renderer.render_coach(**coaches.as_fields()) + "\n"
+            renderer.render_coach(**remove_colons(coaches.as_fields())) + "\n"
             for coaches in self.coaches
             if not coaches.isempty()
         )

--- a/code_rypl/model.py
+++ b/code_rypl/model.py
@@ -316,18 +316,14 @@ class RplmFile:
 
     def export_into(self, file: TextIO, *, renderer: RplmFileRenderer) -> None:
 
-        remove_colons: Callable[[dict[str, str]], dict[str, str]] = lambda dct: {
-            k: v.lstrip(":") for k, v in dct.items()
-        }
-
         file.writelines(
-            renderer.render_player(**remove_colons(player.as_fields())) + "\n"
+            renderer.render_player(**player.as_fields()) + "\n"
             for player in self.players
             if not player.isempty()
         )
 
         file.writelines(
-            renderer.render_coach(**remove_colons(coaches.as_fields())) + "\n"
+            renderer.render_coach(**coaches.as_fields()) + "\n"
             for coaches in self.coaches
             if not coaches.isempty()
         )

--- a/code_rypl/renderers/tools.py
+++ b/code_rypl/renderers/tools.py
@@ -36,6 +36,9 @@ _prepositions = {
 
 
 def normalize_school(school: str) -> str:
+    # capitalize the first letter of each word unless it is
+    # a preposition or there is a capital letter in the word
+
     if school.startswith(":"):
         return ":" + school.lstrip(":").strip()
     else:

--- a/code_rypl/renderers/tools.py
+++ b/code_rypl/renderers/tools.py
@@ -1,0 +1,101 @@
+sport_abrev_to_formal_name = {
+    "hky": "Hockey",
+    "bball": "Basketball",
+    "soc": "Soccer",
+    "baseb": "Baseball",
+    "softb": "Softball",
+    "lax": "Lacrosse",
+    "fb": "Football",
+    "fhky": "Field Hockey",
+}
+
+category_formal_to_variations = {
+    "Men's": {"m", "men", "man", "male", "masc"},
+    "Women's": {"w", "women", "woman", "female", "femme"},
+    "None": {"n", "none", "enby"},
+}
+
+_prepositions = {
+    "the",
+    "at",
+    "in",
+    "from",
+    "over",
+    "of",
+    "and",
+    "upon",
+    "with",
+    "on",
+    "to",
+    "by",
+}
+
+# TODO: add methods to check if sport, category, and season are valid so they can be
+#   highlighted in the UI when the user types bad formats. but remember to be
+#   conservative and only give false when known to be bad. (eg "2" for year)
+
+
+def normalize_school(school: str) -> str:
+    if school.startswith(":"):
+        return ":" + school.lstrip(":").strip()
+    else:
+        return " ".join(
+            map(
+                lambda s: (  # TODO: make this not crap
+                    (s.capitalize() if s.lower() == s else s)
+                    if s.lower() not in _prepositions
+                    else s.lower()
+                ),
+                filter(None, school.split()),
+            )
+        )
+
+
+def normalize_sports(sport: str) -> str:
+
+    # if the starts starts with a colon then only stip (including the space after the colon)
+    if sport.startswith(":"):
+        return ":" + sport.lstrip(":").strip()
+
+    matchable = sport.replace(" ", "").strip().lower()
+
+    # if the sport a value in the known_sport_abbrevs then return the key
+    for abbrev, full_name in sport_abrev_to_formal_name.items():
+        if matchable == abbrev:
+            return full_name
+        elif matchable == full_name.lower().replace(" ", ""):
+            return full_name
+    else:
+        return sport.strip()
+
+
+def normalize_category(raw_cato: str) -> str:
+    # if the starts starts with a colon then only stip (including the space after the colon)
+    if raw_cato.startswith(":"):
+        return ":" + raw_cato.lstrip(":").strip()
+
+    matchable = raw_cato.replace(" ", "").strip().lower().lstrip("'s")
+
+    for formal, variations in category_formal_to_variations.items():
+        if matchable in variations:
+            return formal
+    else:
+        return raw_cato.strip()
+
+
+def normalize_season(season: str) -> str:
+    if season.startswith(":"):
+        return ":" + season.lstrip(":").strip()
+
+    end_raw: str | None
+    if "-" in season:
+        start_raw, end_raw = filter(None, season.split("-"))
+    else:
+        start_raw, end_raw = season, None
+
+    start = start_raw.strip()
+
+    if end_raw is None and len(start) == 4 and start.isnumeric():
+        return f"{start}-{(int(start)+1)%100:02}"
+    else:
+        return season.strip()


### PR DESCRIPTION
This adds several features, primarily in the meta data input section.
- it adds normalizing functions to the inputs
    - Ex: `M`, and `men`, and `man's` all turn into `Men's` 
    - Ex: `rochester institute of technology` -> `Rochester Institute of Technology` (words with capitals in the middle are left as-is)
    - Ex: `hky` or `hoCKey` turn into `Hockey`
- however, it can be escaped by prefixing the field with  a ':'

- the sports and  category field also have suggestions popups for inputs 