### PR TITLE
add second check for exit w/o saving changes, fix bugs

### DIFF
--- a/code_rypl/document.py
+++ b/code_rypl/document.py
@@ -262,9 +262,9 @@ class CodeRyplDocumentWindow(QMainWindow):
         if should_close:
             return super().close()
         else:
-            False
+            return False
 
-    def _check_for_save_on_close(self) -> None:
+    def _check_for_save_on_close(self) -> bool:
         if self.model.changed():
             # make a popup to ask if they want to save
             popup = QMessageBox(self)
@@ -275,7 +275,7 @@ class CodeRyplDocumentWindow(QMainWindow):
             popup.setDefaultButton(QMessageBox.Save)
             popup.setWindowTitle("Unsaved Changes")
             popup.setIcon(QMessageBox.Warning)
-            choice = popup.exec_()
+            choice = popup.exec()
             # if they choose to save, save
             if choice == QMessageBox.Save:
                 self.save()
@@ -284,8 +284,21 @@ class CodeRyplDocumentWindow(QMainWindow):
                 print("cancel")
                 return False
             else:
-                blocking_popup("Unsaved changes discarded")
-                return True
+                double_check = QMessageBox(self)
+                double_check.setText(
+                    "Are you sure you want to quit and discard all changes?"
+                )
+                double_check.setStandardButtons(
+                    QMessageBox.Cancel | QMessageBox.Discard
+                )
+                double_check.setWindowTitle("Are you sure?")
+                double_check.setDefaultButton(QMessageBox.Cancel)
+                double_check.setIcon(QMessageBox.Warning)
+                check = double_check.exec()
+                if check == QMessageBox.Cancel:
+                    return False
+                elif check == QMessageBox.Discard:
+                    return True
         return False
 
     def export_replacements(self):
@@ -483,7 +496,10 @@ class CodeRyplDocumentWindow(QMainWindow):
 
         if about_width_of is not None:
             widget.setFixedWidth(
-                QFontMetrics(widget.font()).boundingRect(about_width_of).width() * 1.25
+                int(
+                    QFontMetrics(widget.font()).boundingRect(about_width_of).width()
+                    * 1.25
+                )
             )
 
         if on_change is not None:

--- a/code_rypl/renderers/default.py
+++ b/code_rypl/renderers/default.py
@@ -67,34 +67,6 @@ def abbv_sex(text: str) -> str:
         raise SexError(f"unkown sex {text!r}, allowed include men, women, and none")
 
 
-def abbv_sport(sport: str) -> str:
-    """
-    Abbreviates a sport name.
-    """
-    matchable = matchify(sport)
-    for abbv, formal in sport_abrev_to_formal_name.items():
-        if matchable in {abbv, matchify(formal)}:
-            return abbv
-    raise SportsAbbreviationError(
-        f"{sport!r} is not a valid sport. valid sports are: {', '.join(map(repr,sorted(sport_abrev_to_formal_name.keys())))}"
-    )
-
-
-def abbv_sex(text: str) -> str:
-
-    normed = norm_or_pass(normalize_category, strip_escape(text))
-
-    print(f"{normed=!r}")
-    if normed == "Men's":
-        return "m"
-    elif normed == "women's":
-        return "w"
-    elif normed == "None":
-        return "n"
-    else:
-        raise SexError(f"unkown sex {text!r}, allowed include men, women, and none")
-
-
 class RplmFileRenderer:
     def __init__(self, *, school: str, sport: str, category: str, season: str) -> None:
 


### PR DESCRIPTION
closes #28 . A second confirmation dialog box will now spawn if user tries to exit without saving changes. 

fixed bugs with _make_metatext_input in `code_rpyl/document.py` and duplication of abbv_sport and abbv_sex in `code_rypl/renderers/defauly.py`.