### PR TITLE
Fix opening many docs

### DIFF
--- a/code_rypl/model.py
+++ b/code_rypl/model.py
@@ -377,9 +377,12 @@ class RplmList(Generic[R], QAbstractTableModel):
         self,
         data: Iterable[R],
         set_selected_cell: Callable[[QModelIndex], None] = None,
-        normalizers: dict[int, Callable[[str], str]] = {},
+        normalizers: dict[int, Callable[[str], str]] | None = None,
     ):
         super().__init__()
+
+        # input sanitization
+        normalizers = {} if normalizers is None else normalizers
 
         self._data = list(data)
         assert len(self._data) > 0, f"cannot create an empty RplmList"


### PR DESCRIPTION
I did a python mistake and forgot to make a new dict for every normalizer's dict in the `RplmList` class...
Meaning it would cause an error when opening other docs