### PR TITLE
Running PR for developing the Import feature

### DIFF
--- a/code_rypl/document.py
+++ b/code_rypl/document.py
@@ -120,6 +120,7 @@ class CodeRyplMenuBar(QMenuBar):
         edit_menu.addAction("Remove Empty Lines", self.remove_empty_lines)
 
     def open_file(self) -> None:
+        # TODO: consider adding importable files.. however I probably think those shoudl be seaprate
         filename, _ = QFileDialog.getOpenFileName(
             self, "Open File", str(self.doc._last_export_path), "RPLM Files (*.rplm)"
         )

--- a/code_rypl/document.py
+++ b/code_rypl/document.py
@@ -85,7 +85,9 @@ class CodeRyplMenuBar(QMenuBar):
         file_menu.addAction("Save", self.doc.save, "Ctrl+S")
         file_menu.addAction("Save As", self.doc.save_as, "Ctrl+Shift+S")
         file_menu.addSeparator()
-        # export
+        # imports / export
+        file_menu.addAction("Import from file", self.import_from_file, "Ctrl+Shift+I")
+        file_menu.addAction("Import from URL", self.import_from_url, "Ctrl+Shift+U")
         file_menu.addAction("Export", self.doc.export_replacements, "Ctrl+Shift+E")
         file_menu.addAction("Close", self.doc.close, "Ctrl+W")
 
@@ -141,6 +143,16 @@ class CodeRyplMenuBar(QMenuBar):
 
     def remove_empty_lines(self) -> None:
         self.doc.model.remove_empty_lines()
+
+    def import_from_file(self) -> None:
+
+        blocking_popup("Import from file not implemented yet")
+        return
+
+    def import_from_url(self) -> None:
+
+        blocking_popup("Import from url not implemented yet")
+        return
 
 
 # maybe name this code ryple document?

--- a/code_rypl/importers/template.py
+++ b/code_rypl/importers/template.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import *
+from io import StringIO
+
+
+from ..model import Player, Coach
+
+
+class InputParser:
+    def __init__(self, contents: str) -> None:
+        pass
+
+    def school(self) -> None | str:
+        return None
+
+    def sport(self) -> None | str:
+        return None
+
+    def category(self) -> None | str:
+        return None
+
+    def season(self) -> None | str:
+        return None
+
+    def parse_players(self) -> Iterable[Player]:
+        raise NotImplementedError
+
+    def parse_coaches(self) -> Iterable[Coach]:
+        raise NotImplementedError


### PR DESCRIPTION
Here I've added a proposed format for import parsers in the `/importers` folder where each module will parse a different file or site type. It also adds stubs for the 'import from File' and 'import from URL' to the file menu

TODO:
- make away (probably as class methods) to check if a file or site contents contain parseable data
- add a way to differential between file and site generators because file should also check the extension type 
-  make two templates instead of one
-  make the templates protocols and have the actual importers subclass them 