### PR TITLE
Instrument logging

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -3,14 +3,14 @@
 # make build-time version of the source
 rm -rf build
 mkdir build
-cp -r code_rypl/ build/code_rypl_build/
+cp -r code_rypl/ build/code_rypl/
 
-# freeze the version info
-python3 build/code_rypl_build/versioning.py --pre-process-in-place
+# freeze the version info, pass through build mode ($@)
+python3 build/code_rypl/versioning.py --pre-process-in-place $@
 
 # package the source
 pyinstaller --noconfirm\
     --windowed\
     --name=CodeRypl\
-    build/code_rypl_build/__main__.py
-    # --icon=icon.ico\
+    build/code_rypl/__main__.py
+# --icon=icon.ico\

--- a/build-package.sh
+++ b/build-package.sh
@@ -1,12 +1,16 @@
+#!/bin/bash
 
-# check if pyinstaller is installed
-pip show pyinstaller
-if [ $? -eq 1 ]; then
-    pip install pyinstaller
-fi
+# make build-time version of the source
+rm -rf build
+mkdir build
+cp -r code_rypl/ build/code_rypl_build/
 
+# freeze the version info
+python3 build/code_rypl_build/versioning.py --pre-process-in-place
+
+# package the source
 pyinstaller --noconfirm\
     --windowed\
     --name=CodeRypl\
-    code_rypl/__main__.py
+    build/code_rypl_build/__main__.py
     # --icon=icon.ico\

--- a/code_rypl/app.py
+++ b/code_rypl/app.py
@@ -9,7 +9,12 @@ from . import auto_log
 
 from .document import CodeRyplDocumentWindow
 
+import PySide6
 from PySide6.QtWidgets import QApplication
+
+print(f"using PySide version {PySide6.__version__}")
+
+# get the current app version
 
 
 class CodeRyplApplication(QApplication):

--- a/code_rypl/app.py
+++ b/code_rypl/app.py
@@ -5,6 +5,7 @@ from typing import *
 import sys
 
 from . import auto_log
+from . import versioning
 
 
 from .document import CodeRyplDocumentWindow
@@ -13,6 +14,8 @@ import PySide6
 from PySide6.QtWidgets import QApplication
 
 print(f"using PySide version {PySide6.__version__}")
+print("--- CodeRypl version info ---")
+print(versioning.full_version())
 
 # get the current app version
 

--- a/code_rypl/app.py
+++ b/code_rypl/app.py
@@ -4,6 +4,9 @@ from typing import *
 
 import sys
 
+from . import auto_log
+
+
 from .document import CodeRyplDocumentWindow
 
 from PySide6.QtWidgets import QApplication

--- a/code_rypl/auto_log.py
+++ b/code_rypl/auto_log.py
@@ -77,7 +77,8 @@ print(f"{sys.executable=!r}")
 print(f"{sys.argv=!r}")
 
 print(
-    f"logging stderr to: {tmperr.name!r}, "
-    f"stdout to: {tmpout.name!r}, "
-    f"both to: {tmplog.name!r}"
+    "logging:\n"
+    f"\tstderr to: {tmperr.name!r}\n"
+    f"\tstdout to: {tmpout.name!r}\n"
+    f"\tboth to: {tmplog.name!r}"
 )

--- a/code_rypl/auto_log.py
+++ b/code_rypl/auto_log.py
@@ -8,8 +8,10 @@ import datetime
 import tempfile
 from typing import *
 
+from .versioning import BuildMode, __build_mode__ as build_mode
+
 # if the sys._getframe api is available inject statements into print indicating the module
-if hasattr(sys, "_getframe"):
+if hasattr(sys, "_getframe") and build_mode != BuildMode.release:
     _orig_print = builtins.print
 
     _last_moule_name: None | str = None

--- a/code_rypl/auto_log.py
+++ b/code_rypl/auto_log.py
@@ -1,0 +1,83 @@
+"""
+Intercepts write() calls to stdout and stderr and logs them to the temp dir
+"""
+
+from os import path
+import sys
+import datetime
+import tempfile
+from typing import *
+
+
+def patch_in_second(*, fromstd: TextIO, tofile: TextIO) -> None:
+
+    fromstd_flush = fromstd.flush
+    fromstd_seek = fromstd.seek
+    fromstd_truncate = fromstd.truncate
+    fromstd_write = fromstd.write
+    fromstd_writelines = fromstd.writelines
+
+    def flush() -> None:
+        fromstd_flush()
+        tofile.flush()
+
+    def seek(offset: int, whence: int = 0) -> int:
+        ret = fromstd_seek(offset, whence)
+        tofile.seek(offset, whence)
+        return ret
+
+    def truncate(size: int = None) -> int:
+        ret = fromstd_truncate(size)
+        tofile.truncate(size)
+        return ret
+
+    def write(s: AnyStr) -> int:
+        ret = fromstd_write(s)
+        tofile.write(s)
+        return ret
+
+    def writelines(lines: List[AnyStr]) -> None:
+        fromstd_writelines(lines)
+        tofile.writelines(lines)
+
+    fromstd.flush = flush
+    fromstd.seek = seek
+    fromstd.truncate = truncate
+    fromstd.write = write
+    fromstd.writelines = writelines
+
+
+# --- perform patching ---
+now = datetime.datetime.now()
+
+prefix = f"code_rypl_{now.strftime('%Y-%m-%d_%H-%M-%S')}_"
+
+_tmperr_fd, _tmperr_name = tempfile.mkstemp(suffix=".err", prefix=prefix)
+_tmpout_fd, _tmpout_name = tempfile.mkstemp(suffix=".out", prefix=prefix)
+_tmplog_fd, _tmplog_name = tempfile.mkstemp(suffix=".log", prefix=prefix)
+
+tmperr = open(_tmperr_name, "w")
+tmpout = open(_tmpout_name, "w")
+tmplog = open(_tmplog_name, "w")
+
+# the individual styles
+patch_in_second(fromstd=sys.stderr, tofile=tmperr)
+patch_in_second(fromstd=sys.stdout, tofile=tmpout)
+
+# have the combined output go to the log file
+patch_in_second(fromstd=sys.stdout, tofile=tmplog)
+patch_in_second(fromstd=sys.stderr, tofile=tmplog)
+
+# # and output
+print("CodeRypl is starting up...")
+
+print(f"{sys.version=!r}")
+print(f"{sys.platform=!r}")
+print(f"{sys.executable=!r}")
+print(f"{sys.argv=!r}")
+
+print(
+    f"logging stderr to: {tmperr.name!r}, "
+    f"stdout to: {tmpout.name!r}, "
+    f"both to: {tmplog.name!r}"
+)

--- a/code_rypl/auto_log.py
+++ b/code_rypl/auto_log.py
@@ -2,15 +2,37 @@
 Intercepts write() calls to stdout and stderr and logs them to the temp dir
 """
 
-from os import path
-from re import escape
 import sys
+import builtins
 import datetime
 import tempfile
 from typing import *
 
+# if the sys._getframe api is available inject statements into print indicating the module
+if hasattr(sys, "_getframe"):
+    _orig_print = builtins.print
 
-def patch_in_second(*, fromstd: TextIO, tofiles: TextIO | Iterable[TextIO]) -> None:
+    _last_moule_name: None | str = None
+
+    def _moduled_print(*args, **kwargs) -> None:
+        global _last_moule_name
+        outer = sys._getframe(1)
+
+        modname = outer.f_globals.get("__name__", None)
+        # f"[{modinfo}]" if modinfo is not None else "[?unknown]"
+        if modname is not None and modname != _last_moule_name:
+            _last_moule_name = modname
+            _orig_print(f"@[in: {modname}]")
+        elif modname is None:
+            _last_moule_name = None
+            _orig_print("@[in: ?unknown]")
+
+        _orig_print(*args, **kwargs)
+
+    builtins.print = _moduled_print
+
+
+def mirror_written(*, fromstd: TextIO, tofiles: tuple[TextIO, ...]) -> None:
     """
     wrap key methods used by print/etc to also write output to a file in addition to stdout|stderr
     """
@@ -58,11 +80,11 @@ def patch_in_second(*, fromstd: TextIO, tofiles: TextIO | Iterable[TextIO]) -> N
         for file in tofiles:
             file.writelines(lines)
 
-    fromstd.flush = flush
-    fromstd.seek = seek
-    fromstd.truncate = truncate
-    fromstd.write = write
-    fromstd.writelines = writelines
+    fromstd.flush = flush  # type: ignore[assignment]
+    fromstd.seek = seek  # type: ignore[assignment]
+    fromstd.truncate = truncate  # type: ignore[assignment]
+    fromstd.write = write  # type: ignore[assignment]
+    fromstd.writelines = writelines  # type: ignore[assignment]
 
 
 # --- perform patching ---
@@ -79,20 +101,12 @@ tmpout = open(_tmpout_name, "w")
 tmplog = open(_tmplog_name, "w")
 
 # the individual styles
-patch_in_second(fromstd=sys.stderr, tofile=tmperr)
-patch_in_second(fromstd=sys.stdout, tofile=tmpout)
+mirror_written(fromstd=sys.stderr, tofiles=(tmperr, tmplog))
+mirror_written(fromstd=sys.stdout, tofiles=(tmpout, tmplog))
 
-# have the combined output go to the log file
-patch_in_second(fromstd=sys.stdout, tofile=tmplog)
-patch_in_second(fromstd=sys.stderr, tofile=tmplog)
 
 # # and output
-print("CodeRypl is starting up...")
-
-print(f"{sys.version=!r}")
-print(f"{sys.platform=!r}")
-print(f"{sys.executable=!r}")
-print(f"{sys.argv=!r}")
+print("CodeRypl logging starting up...")
 
 print(
     "logging:\n"
@@ -100,3 +114,5 @@ print(
     f"\tstdout to: {tmpout.name!r}\n"
     f"\tboth to: {tmplog.name!r}"
 )
+
+print("CodeRypl logging setup finished.")

--- a/code_rypl/auto_log.py
+++ b/code_rypl/auto_log.py
@@ -22,7 +22,11 @@ if hasattr(sys, "_getframe") and build_mode != BuildMode.release:
 
         modname = outer.f_globals.get("__name__", None)
         # f"[{modinfo}]" if modinfo is not None else "[?unknown]"
-        if modname is not None and modname != _last_moule_name:
+        if (
+            modname.startswith("code_rypl")
+            and modname is not None
+            and modname != _last_moule_name
+        ):
             _last_moule_name = modname
             _orig_print(f"@[module: {modname}]")
         elif modname is None:

--- a/code_rypl/versioning.py
+++ b/code_rypl/versioning.py
@@ -1,0 +1,182 @@
+"""
+used to derive the version and the build number.
+This file may be pre-processed by the build system.
+
+test script:
+```bash
+    rm -rf build/code_rypl_build \
+    && cp -r code_rypl build/code_rypl_build\
+    && py build/code_rypl_build/versioning.py --pre-process-in-place
+```
+"""
+
+
+import sys
+import datetime
+from typing import *
+import git
+from enum import Enum
+
+
+class BuildMode(Enum):
+    dev = "dev"
+    release = "release"
+    # TODO: review later, left this in for now. It'd be cool to have debug mode but
+    # without a good reason it does not make sense
+    debug = "debug"
+
+    def __repr__(self) -> str:
+        # DO NOT CHANGE THIS LINE, it is used by the build system
+        # fmt: off
+        return f"{type(self).__name__}.{self.name}"
+        # fmt: on
+
+
+# ===== possible pre-processed values =====
+# === DO NOT CHANGE THESE LINES ====
+# START
+# fmt: off
+# --- flag ---
+__pre_processed__: bool = False
+# --- python / build related ---
+__build_date__: str = ""
+__build_time__: str = ""
+__build_platform__: str = ""
+__python_build_version__: str = ""
+# --- git / source related ---
+__branch_name__: str = ""
+__build_mode__: None | BuildMode = None
+__build_number__: str = ""
+# fmt: on
+# END
+# === RESUME NORMAL CODE ====
+
+
+# DO NOT CHANGE THE NEXT LINE, it is used by the build system
+if not __pre_processed__:
+    # resuming normal code
+    assert __build_date__ == ""
+    assert __build_time__ == ""
+    assert __build_platform__ == ""
+    assert __python_build_version__ == ""
+
+    now = datetime.datetime.now()
+
+    __build_date__ = now.strftime("%d%b%Y")
+    __build_time__ = now.strftime("%Hh%Mm%Ss")
+    __build_platform__: str = sys.platform
+    __python_build_version__: str = sys.version
+
+    assert __branch_name__ == ""
+    assert __build_mode__ is None
+    assert __build_number__ == ""
+
+    repo = git.Repo(search_parent_directories=True)
+    __branch_name__ = repo.active_branch.name
+    __build_mode__ = BuildMode.dev
+    __build_number__ = repo.git.rev_parse(repo.active_branch.commit.hexsha, short=7)
+
+
+def full_version() -> str:
+    return (
+        "version:(\n\t"
+        + ",\n\t".join(
+            (
+                f"{__build_date__ = !r}",
+                f"{__build_time__ = !r}",
+                f"{__build_platform__ = !r}",
+                f"{__python_build_version__ = !r}",
+                f"{__pre_processed__ = !r}",
+                f"{__branch_name__ = !r}",
+                f"{__build_mode__ = !r}",
+                f"{__build_number__ = !r}",
+            )
+        )
+        + "\n)"
+    )
+
+
+if __name__ == "__main__":
+    if "--pre-process-in-place" not in sys.argv:
+        print(f"skipping pre-processing, use --pre-process-in-place to enable")
+        print(full_version())
+    else:
+
+        print(f"adding version and build info with pre-processing to {__file__!r}")
+        assert __file__.endswith("build/code_rypl_build/versioning.py"), (
+            "code_rypl must be copied to to a 'build/' directory to "
+            f"be pre-processed, in {__file__}"
+        )
+
+        # determine the bulid mode
+        if "--build-mode=release" in sys.argv:
+            build_mode = BuildMode.dev
+        elif "--build-mode=debug" in sys.argv:
+            build_mode = BuildMode.debug
+        else:
+            # if it is specified here then it must be
+            if any((fullarg := arg).startswith("--build-mode=") for arg in sys.argv):
+                assert fullarg == "--build-mode=dev"
+            build_mode = BuildMode.dev
+
+        with open(__file__, "r") as file:
+            lines = file.readlines()
+
+        # fmt: off
+        replacements = {
+            '__build_date__: str = ""\n':
+            f'__build_date__: Literal["{__build_date__}"] = "{__build_date__}"\n',
+            
+            '__build_time__: str = ""\n':
+            f'__build_time__: Final[str] = "{__build_time__}"\n',
+            
+            '__build_platform__: str = ""\n':
+            f'__build_platform__: Literal["{__build_platform__}"] = "{__build_platform__}"\n',
+
+            '__python_build_version__: str = ""\n':
+            f'__python_build_version__: Literal["{__python_build_version__}"] = "{__python_build_version__}"\n',
+
+            "__pre_processed__: bool = False\n":
+            "__pre_processed__: Literal[True] = True\n",
+
+            '__branch_name__: str = ""\n': 
+            f'__branch_name__: Literal["{__branch_name__}"] = "{__branch_name__}"\n',
+
+            "__build_mode__: None | BuildMode = None\n": 
+            f"__build_mode__: Final[BuildMode] = {build_mode}\n",
+
+            '__build_number__: str = ""\n':
+            f'__build_number__: Literal["{__build_number__}"] = "{__build_number__}"\n',
+        }
+        # fmt: on
+
+        with open(__file__, "w") as file:
+            itrbl = iter(lines)
+            for line in itrbl:
+
+                if line == ("if not __pre_processed__:\n") or line.startswith(
+                    'if __name__ == "__main__"'
+                ):
+                    # skip the next indentation level
+                    file.write(f"# {line}")
+                    next_line = next(itrbl)
+                    while next_line is not None and (
+                        next_line.startswith(" ")
+                        or next_line.startswith("\n")
+                        or next_line.startswith("#")
+                    ):  # while starts with an indent
+                        file.write(f"# {next_line}")
+                        next_line = next(itrbl, None)
+                    else:
+                        if next_line is None:
+                            continue
+                        line = next_line
+
+                if line in replacements:
+                    file.write(replacements.pop(line))
+                else:
+                    file.write(line)
+
+        assert (
+            len(replacements) == 0
+        ), f"unable to pre-process {__file__}, cound not find where to replace {set(replacements)}"

--- a/code_rypl/versioning.py
+++ b/code_rypl/versioning.py
@@ -4,9 +4,9 @@ This file may be pre-processed by the build system.
 
 test script:
 ```bash
-    rm -rf build/code_rypl_build \
-    && cp -r code_rypl build/code_rypl_build\
-    && py build/code_rypl_build/versioning.py --pre-process-in-place
+    rm -rf build/code_rypl \
+    && cp -r code_rypl build/code_rypl\
+    && py build/code_rypl/versioning.py --pre-process-in-place
 ```
 """
 
@@ -103,7 +103,7 @@ if __name__ == "__main__":
     else:
 
         print(f"adding version and build info with pre-processing to {__file__!r}")
-        assert __file__.endswith("build/code_rypl_build/versioning.py"), (
+        assert __file__.endswith("build/code_rypl/versioning.py"), (
             "code_rypl must be copied to to a 'build/' directory to "
             f"be pre-processed, in {__file__}"
         )

--- a/code_rypl/versioning.py
+++ b/code_rypl/versioning.py
@@ -64,8 +64,8 @@ if not __pre_processed__:
 
     __build_date__ = now.strftime("%d%b%Y")
     __build_time__ = now.strftime("%Hh%Mm%Ss")
-    __build_platform__: str = sys.platform
-    __python_build_version__: str = sys.version
+    __build_platform__: str = sys.platform  # type: ignore[no-redef]
+    __python_build_version__: str = sys.version  # type: ignore[no-redef]
 
     assert __branch_name__ == ""
     assert __build_mode__ is None
@@ -159,7 +159,7 @@ if __name__ == "__main__":
                 ):
                     # skip the next indentation level
                     file.write(f"# {line}")
-                    next_line = next(itrbl)
+                    next_line: None | str = next(itrbl)
                     while next_line is not None and (
                         next_line.startswith(" ")
                         or next_line.startswith("\n")

--- a/code_rypl/versioning.py
+++ b/code_rypl/versioning.py
@@ -128,13 +128,13 @@ if __name__ == "__main__":
             f'__build_date__: Literal["{__build_date__}"] = "{__build_date__}"\n',
             
             '__build_time__: str = ""\n':
-            f'__build_time__: Final[str] = "{__build_time__}"\n',
+            f'__build_time__: Literal["{__build_time__}"] = "{__build_time__}"\n',
             
             '__build_platform__: str = ""\n':
             f'__build_platform__: Literal["{__build_platform__}"] = "{__build_platform__}"\n',
 
             '__python_build_version__: str = ""\n':
-            f'__python_build_version__: Literal["{__python_build_version__}"] = "{__python_build_version__}"\n',
+            f'__python_build_version__: Final[str] = "{__python_build_version__}"\n',
 
             "__pre_processed__: bool = False\n":
             "__pre_processed__: Literal[True] = True\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ### ... ###
 PySide6 ~= 6.2.0
 msgpack ~= 1.0.0
-click ~= 8.0.0
+GitPython ~= 3.1.0


### PR DESCRIPTION
closes #26 

## The changes in this branch include:
- mirrors what is written into stdout and stderr into temp files marked with the date: `.out` and `.err` respectively
- also mirrors the combination of both stdout and stderr into a sing `.log` file next to them (this is more normal for python)
- when the `sys._getframe(...)` API is available calling `print()` will insert extra an extra message when the program transitions between modules
    > The syntax of the output looks like `@[module: code_rypl.app]` for any given module in the `code_rypl/` directory
- add a `versioning.py`  module that auto fetches information about when the program was built or run (see below)
    > the build info in versioning.py can be frozen by copying `code_rypl/` int a folder named  `code_ryple_build` and running `python code_ryple_build/versioning.py --pre-process-in-place`. Doing this will edit the source code of `code_ryple_build/versioning.py` so the build info is backed into the source of the file. [This is meant for further use in a build system]

<br>
<br>
<br>


### `versioning.py` provides
   >  
    - `.__pre_processed__`: weather or not `versioning.py` was run with `--pre-process-in-place`
    - `.__build_date__`: the day the program was built, formatted "01Jan1970" 
    - `.__build_time__`: the time the program was built, formatted "00h00m00s"
    - `.__build_platform__`: the `sys.platform` at the time of build
    - `.__python_build_version__`: the `sys.version` string at the time of build
    - `.__branch_name__`: the name of the active branch in the repo (at time of build)
    - `.__build_mode__`: an Enum `BuildMode` that is on of 
    - `.__build_number__`: the "short hash" of the current git branch. (the first 7 digits of the hexsha commit hash)
    - `.full_version()`: the above info returned in a (parseable, shhh) string